### PR TITLE
Revert "limit size of bio photos for designers and crew members"

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -11,7 +11,6 @@
 @import 'shared/_main-content';
 @import 'shared/_bio';
 @import 'shared/_splash';
-@import 'shared/_tall-bio-photo-layout';
 
 @import 'styles/layout';
 @import 'styles/music';
@@ -19,4 +18,3 @@
 @import 'styles/team';
 @import 'styles/designers';
 @import 'styles/welcome';
-@import 'styles/bio-fixes';

--- a/app/assets/stylesheets/shared/_tall-bio-photo-layout.scss
+++ b/app/assets/stylesheets/shared/_tall-bio-photo-layout.scss
@@ -1,7 +1,0 @@
-@mixin tallBioPhotoLayout() {
-  .photo {
-    width: 200px;
-    max-width: unset;
-    min-width: unset;
-  }
-}

--- a/app/assets/stylesheets/styles/bio-fixes.scss
+++ b/app/assets/stylesheets/styles/bio-fixes.scss
@@ -1,4 +1,0 @@
-
-.designer .bio-item, .team_member .bio-item {
-  @include tallBioPhotoLayout();
-}


### PR DESCRIPTION
Reverts keplerites/kepler#29

This screwed up the layout on mobile: it remained too wide on my iPhone SE, making it necessary to scroll left and right to read the bio.

I have already rolled the server back.