### PR TITLE
Add second teaser to about page

### DIFF
--- a/app/assets/stylesheets/styles/welcome.scss
+++ b/app/assets/stylesheets/styles/welcome.scss
@@ -18,17 +18,22 @@
     display: flex;
     flex-flow: row wrap;
     justify-content: flex-start;
-    .video {
+    .video-column {
       margin-right: 25px;
-      margin-bottom: 25px;
-      height: 300px;
       flex-grow: 1;
+      display: flex;
+      flex-flow: column nowrap;
       @media (max-width: $tabletWidth) {
         width: 100%;
         margin-right: 0;
       }
-      @media (max-width: 350px) {
-        height: 170px;
+      .video {
+        height: calc(30*1vw);
+        min-width: 40vw;
+        padding-bottom: 25px;
+        @media (max-width: $tabletWidth) {
+          height: calc(44*1vw);
+        }
       }
     }
   }

--- a/app/assets/stylesheets/styles/welcome.scss
+++ b/app/assets/stylesheets/styles/welcome.scss
@@ -21,8 +21,8 @@
     .video {
       margin-right: 25px;
       margin-bottom: 25px;
-      width:500px;
       height: 300px;
+      flex-grow: 1;
       @media (max-width: $tabletWidth) {
         width: 100%;
         margin-right: 0;

--- a/app/views/welcome/about.html.erb
+++ b/app/views/welcome/about.html.erb
@@ -1,23 +1,28 @@
 <div class='about'>
   <div class='main-content'>
     <div class='content-wrapper'>
+      <div class='inner-row'>
+        <div class='video-column'>
+          <div class='video'>
+            <iframe src="https://player.vimeo.com/video/229126511" width="100%" height="100%" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+          </div>
+          <div class='video'>
+            <iframe src="https://player.vimeo.com/video/231153167" width="100%" height="100%" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+          </div>
+        </div>
+        <div class='event-details-column'>
+          <div class='location'>
+            <%= link_to "https://www.google.de/maps/place/52%C2%B033'20.3%22N+13%C2%B024'53.3%22E", target: "_blank" do %>
+              5233'20.3"N 13°24'53.3"E (WBB Berlin)
+            <% end %>
+          </div>
+          <div class='exhibition-details'>Exhibition opening 16.09.2017, 6pm</div>
+          <div class='closing-party-details'>Kepler 452b Launch 23.09.2017, 8pm doors open</div>
+          <div><%= link_to 'info@kepler452b.org', 'mailto:info@kepler452b.org' %></div>
+        </div>
+      </div>
       <div class='main-row'>
         <div class='main-column'>
-          <div class='inner-row'>
-            <div class='video'>
-              <iframe src="https://player.vimeo.com/video/229126511" width="100%" height="100%" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-            </div>
-            <div class='event-details-column'>
-              <div class='location'>
-                <%= link_to "https://www.google.de/maps/place/52%C2%B033'20.3%22N+13%C2%B024'53.3%22E", target: "_blank" do %>
-                  5233'20.3"N 13°24'53.3"E (WBB Berlin)
-                <% end %>
-              </div>
-              <div class='exhibition-details'>Exhibition opening 16.09.2017, 6pm</div>
-              <div class='closing-party-details'>Kepler 452b Launch 23.09.2017, 8pm doors open</div>
-              <div><%= link_to 'info@kepler452b.org', 'mailto:info@kepler452b.org' %></div>
-            </div>
-          </div>
           <div class='below-content-column'>
             <div class='concept'>
               <b>CONCEPT</b><br />


### PR DESCRIPTION
and fix a layout issue: the right column with the event details wasn't staying on the right in desktop width.

https://github.com/keplerites/kepler/issues/26